### PR TITLE
Set HTTP version to 1.1 for web sockets, a fix for issue #11

### DIFF
--- a/server.py
+++ b/server.py
@@ -48,7 +48,7 @@ class StreamingHttpHandler(BaseHTTPRequestHandler):
             content_type = 'text/html; charset=utf-8'
             tpl = Template(self.server.index_template)
             content = tpl.safe_substitute(dict(
-                ADDRESS='%s:%d' % (self.request.getsockname()[0], WS_PORT),
+                ADDRESS='%s:%d' % ("' + window.location.hostname +'", WS_PORT),
                 WIDTH=WIDTH, HEIGHT=HEIGHT, COLOR=COLOR, BGCOLOR=BGCOLOR))
         else:
             self.send_error(404, 'File not found')


### PR DESCRIPTION
Sets the WS handler to be HTTP Version 1.1 - For Safari on iOS and macOS, issue #11

I've tested this and can confirm it works OK on:

Mac 10.12.4:  Chrome, Safari 
iOS 10.3.1: Safari, Chrome (v58)
Win10:  Edge (v38), Chrome (v57)
Raspbian (Jessie): Chromium (v56)
Windows 10 Mobile:  Edge

When I have access to my Android tablet (and remember) I will check Android too.